### PR TITLE
Add PHP mbstring extension requirement

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -15,7 +15,8 @@ There are a few .htaccess files included in the Scalar build, therefore please m
 
 ***
 If PHP's short_open_tag (<? vs <?php) is turned off, CodeIgniter is supposed to make them operational, but this feature doesn't
-seem to be working properly.  Please make sure short_open_tag is turned on in PHP.
+seem to be working properly.  Please make sure short_open_tag is turned on in PHP. Scalar also requires the non-default PHP extension mbstring. 
+See installation instructions for mbstring http://php.net/manual/en/mbstring.installation.php.
 ***
 
 ***


### PR DESCRIPTION
I installed scalar on a clean CentOS 7 install and encountered:

PHP Fatal error:  Call to undefined function mb_strtolower() in /var/www/html/system/application/views/modules/data/json.php

I discovered this was due to a missing mbstring extension, which when installed corrected the issue.