### PR TITLE
Allow configuration through environment variables

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -30,7 +30,7 @@ Scalar supports servers running SSL (https) out of the box.  If needed we have a
 file to force all requests through https.
 ***
 
-1) 
+1)
 
 Run the SQL script on a fresh MySQL database (e.g., "scalar_store"):
 
@@ -40,24 +40,49 @@ Note that five additional tables will be added after Scalar's first use.
 
 Update database fields (hostname, database, username and password) at:
 
-system/application/config/database.php
+system/application/config/database.php OR you can set the following environment variables:
+
+    SCALAR_DB_HOSTNAME
+    SCALAR_DB_USERNAME
+    SCALAR_DB_PASSWORD
+    SCALAR_DB_DATABASE
+
 
 2)
 
 Add a new SALT string, reCAPTCHA key (for your domain, http://www.google.com/recaptcha/whyrecaptcha), 
 registration key, SoundCloud key, and a few other keys:
 
-system/application/config/local_settings.php
+system/application/config/local_settings.php OR you can set the following environment variables:
+
+    SCALAR_SHASALT
+    SCALAR_RECAPTCHA_PUBLIC_KEY
+    SCALAR_RECAPTCHA_PRIVATE_KEY
+    SCALAR_SOUNDCLOUD_ID
+    SCALAR_DPLA_KEY
+    SCALAR_FLOWPLAYER_KEY
+    SCALAR_GOOGLE_MAPS_KEY
+    SCALAR_EMAIL_REPLYTO_ADDRESS
+    SCALAR_EMAIL_REPLYTO_NAME
+    SCALAR_SMTP_HOST
+    SCALAR_SMTP_USERNAME
+    SCALAR_SMTP_PASSWORD
 
 Add session encryption key ($config['encryption_key']) and cookie/session variable ($config['cookie_prefix']) at:
 
-system/application/config/config.php
+system/application/config/config.php OR you can set the following environment variables:
+
+    SCALAR_ENCRYPTION_KEY
+    SCALAR_COOKIE_PREFIX
+    SCALAR_COOKIE_DOMAIN
 
 3) 
 
 By default, the home page (book index) will display "Scalar" as the page title; this can be updated at:
 
-system/application/language/en/content_lang.php
+system/application/language/en/content_lang.php OR you can set the following environment variables:
+
+    SCALAR_INSTALL_NAME
 
 4) 
 

--- a/system/application/config/config.php
+++ b/system/application/config/config.php
@@ -228,7 +228,7 @@ $config['cache_path'] = '';
 | enabled you MUST set an encryption key.  See the user guide for info.
 |
 */
-$config['encryption_key'] = "";
+$config['encryption_key'] = (getenv('SCALAR_ENCRYPTION_KEY') ? getenv('SCALAR_ENCRYPTION_KEY') : '');
 
 /*
 |--------------------------------------------------------------------------
@@ -261,8 +261,8 @@ $config['sess_time_to_update'] 	= 400;
 | 'cookie_path'   =  Typically will be a forward slash
 |
 */
-$config['cookie_prefix']	= "";
-$config['cookie_domain']	= "";
+$config['cookie_prefix'] = (getenv('SCALAR_COOKIE_PREFIX') ? getenv('SCALAR_COOKIE_PREFIX') : '');
+$config['cookie_domain'] = (getenv('SCALAR_COOKIE_DOMAIN') ? getenv('SCALAR_COOKIE_DOMAIN') : '');
 $config['cookie_path']		= "/";
 
 /*

--- a/system/application/config/database.php
+++ b/system/application/config/database.php
@@ -41,10 +41,10 @@
 $active_group = "default";
 $active_record = TRUE;
 
-$db['default']['hostname'] = 'localhost';
-$db['default']['username'] = '';
-$db['default']['password'] = '';
-$db['default']['database'] = '';
+$db['default']['hostname'] = (getenv('SCALAR_DB_HOSTNAME') ? getenv('SCALAR_DB_HOSTNAME') : 'localhost');
+$db['default']['username'] = (getenv('SCALAR_DB_USERNAME') ? getenv('SCALAR_DB_USERNAME') : '');
+$db['default']['password'] = (getenv('SCALAR_DB_PASSWORD') ? getenv('SCALAR_DB_PASSWORD') : '');
+$db['default']['database'] = (getenv('SCALAR_DB_DATABASE') ? getenv('SCALAR_DB_DATABASE') : '');
 
 $db['default']['dbdriver'] = "mysqli";
 

--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -13,29 +13,29 @@ $config['active_book_list'] = 'book_list';
 $config['active_cover'] = 'cover';
 
 // SALT, any string you want as long as it is complicated
-$config['shasalt'] = '';
+$config['shasalt'] = (getenv('SCALAR_SHASALT') ? getenv('SCALAR_SHASALT') : '');
 
 // chmod permissions when the system creates directories or places uploaded files (e.g., 0775)
 $config['chmod_mode'] = 0775;
 
 // ReCAPTCHA key (leave blank for no ReCAPTCHA)
-$config['recaptcha_public_key'] = '';
-$config['recaptcha_private_key'] = '';
+$config['recaptcha_public_key'] = (getenv('SCALAR_RECAPTCHA_PUBLIC_KEY') ? getenv('SCALAR_RECAPTCHA_PUBLIC_KEY') : '');
+$config['recaptcha_private_key'] = (getenv('SCALAR_RECAPTCHA_PRIVATE_KEY') ? getenv('SCALAR_RECAPTCHA_PRIVATE_KEY') : '');
 
 // Register key (leave blank if no register key required, e.g., array())
 $config['register_key'] = array();
 
 // Soundcloud key
-$config['soundcloud_id'] = '';
+$config['soundcloud_id'] = (getenv('SCALAR_SOUNDCLOUD_ID') ? getenv('SCALAR_SOUNDCLOUD_ID') : '');
 
 // Digital Public Library of America key
-$config['dpla_key'] = '';
+$config['dpla_key'] = (getenv('SCALAR_DPLA_KEY') ? getenv('SCALAR_DPLA_KEY') : '');
 
 // Flowplayer key
-$config['flowplayer_key'] = '';
+$config['flowplayer_key'] = (getenv('SCALAR_FLOWPLAYER_KEY') ? getenv('SCALAR_FLOWPLAYER_KEY') : '');
 
 // Google Maps key
-$config['google_maps_key'] = '';
+$config['google_maps_key'] = (getenv('SCALAR_GOOGLE_MAPS_KEY') ? getenv('SCALAR_GOOGLE_MAPS_KEY') : '');
 
 // Custom message for the book index page (leave blank for no message)				   
 $config['index_msg'] = '';
@@ -45,13 +45,13 @@ $config['book_msg'] = '';
 $config['book_msg_cookie_name'] = 'ci_hide_scalar_book_msg';
 
 // Emails
-$config['email_replyto_address'] = ''; 
-$config['email_replyto_name'] = '';
+$config['email_replyto_address'] = (getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') ? getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') : ''); 
+$config['email_replyto_name'] = (getenv('SCALAR_EMAIL_REPLYTO_NAME') ? getenv('SCALAR_EMAIL_REPLYTO_NAME') : '');
 // SMTP (leave smtp_host field empty to use phpmailer instead). If using Gmail, you may need to enable access in security settings.
-$config['smtp_host'] = ''; 
+$config['smtp_host'] = (getenv('SCALAR_SMTP_HOST') ? getenv('SCALAR_SMTP_HOST') : ''); 
 $config['smtp_auth'] = true; 
-$config['smtp_username'] = '';    
-$config['smtp_password'] = '';     
+$config['smtp_username'] = (getenv('SCALAR_SMTP_USERNAME') ? getenv('SCALAR_SMTP_USERNAME') : '');    
+$config['smtp_password'] = (getenv('SCALAR_SMTP_PASSWORD') ? getenv('SCALAR_SMTP_PASSWORD') : '');     
 $config['smtp_secure'] = 'ssl';   // 'ssl' or 'tls'       
 $config['smtp_port'] = 465; 
 

--- a/system/application/language/en/content_lang.php
+++ b/system/application/language/en/content_lang.php
@@ -3,7 +3,7 @@
 
 $lang['scalar']       = 'Scalar';
 
-$lang['install_name'] = 'Scalar';  // Will be displayed on the top of the book index page, e.g., could be changed to "Scalar for the Maker Lab"
+$lang['install_name'] = (getenv('SCALAR_INSTALL_NAME') ? getenv('SCALAR_INSTALL_NAME') : 'Scalar');  // Will be displayed on the top of the book index page, e.g., could be changed to "Scalar for the Maker Lab"
 
 $lang['book']     = 'book';
 $lang['or']       = 'or';


### PR DESCRIPTION
I think this is a negligible performance hit for a much more flexible configuration. You should probably allow an external config file as well; something like

```
if(file_exists('unversioned_config_file.php'))
    include 'unversioned_config_file.php';
```

at the bottom of the config files.

It would also be nice if all the variables you needed to set before running were in one file (instead of the 3 or 4 now.