### PR TITLE
LDAP authentication option added

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -3,6 +3,13 @@
  * @projectDescription	Application config for Scalar installations
 */
 
+// Optional LDAP authentication settings
+$config['use_ldap'] = 0; // LDAP authentication is off by default
+$config['ldap_server'] = "ldap.server.name";
+$config['ldap_port'] = 389;
+$config['ldap_basedn'] = "dc=organization,dc=tld";
+$config['ldap_uname_field'] = "uid";
+
 // Default melon (Scalar skin), must have a corresponding folder in system/application/views/melons/ 
 $config['active_melon'] = 'cantaloupe';
 

--- a/system/application/models/login_model.php
+++ b/system/application/models/login_model.php
@@ -75,12 +75,20 @@ class Login_model extends User_model {
 
 			$email = trim($_POST['email']);
 			$password = trim($_POST['password']);
-
-			if ($this->has_empty_password($email)) {
-				$result = $this->get_by_email($email);
-			} else {
-				$result = $this->get_by_email_and_password($email, $password);
-			}
+            
+            $result = 0;
+            if ( $this->config->item('use_ldap') ) {
+                $result = $this->get_from_ldap_by_email_and_password($email, $password);
+            }
+            
+            // If they're not in LDAP, or use_ldap is off, then check the database
+            if (!$result) {
+                if ($this->has_empty_password($email)) {
+                    $result = $this->get_by_email($email);
+                } else {
+                    $result = $this->get_by_email_and_password($email, $password);              
+                }
+            }
 
 			if (!$result) {
 				$result = new stdClass;


### PR DESCRIPTION
I wrote this code so we could have our local scalar implementation at Lehigh University use LDAP to authenticate users.  Hopefully it is okay to be included in the main scalar code so that other organizations could use it as well.  By default, LDAP authentication is off and scalar authenticates users using its own database, as normal.