### PR TITLE
Fixed empty password issue with get_from_ldap_by_email_and_password f…

### DIFF
--- a/system/application/models/user_model.php
+++ b/system/application/models/user_model.php
@@ -168,6 +168,10 @@ class User_model extends MY_Model {
         $basedn = $this->config->item('ldap_basedn');
         $uname_field = $this->config->item('ldap_uname_field');
 
+	if ( strlen(trim($password)) == 0 ) {
+           return false;
+	}
+
         $ldapCon = ldap_connect( $ldap_host, $ldap_port );
         if ( !$ldapCon) {
             throw new Exception("Unable to connect to LDAP server");


### PR DESCRIPTION
…unction in user_model.

This is a serious security issue if you're using LDAP and your LDAP server allows anonymous binding.  It allows someone to log in as any LDAP user by just leaving the password empty.  Sorry for the huge oversight there, but this fixes it.