### PR TITLE
Configure SendMail From Address

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -86,6 +86,8 @@ $config['ldap_uname_field'] = (getenv('SCALAR_LDAP_UNAME_FIELD') ? getenv('SCALA
 // Emails
 $config['email_replyto_address'] = (getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') ? getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') : ''); 
 $config['email_replyto_name'] = (getenv('SCALAR_EMAIL_REPLYTO_NAME') ? getenv('SCALAR_EMAIL_REPLYTO_NAME') : '');
+$config['email_from_address'] = (getenv('SCALAR_EMAIL_FROM_ADDRESS') ? getenv('SCALAR_EMAIL_FROM_ADDRESS') : '');
+
 // SMTP (leave smtp_host field empty to use phpmailer instead). If using Gmail, you may need to enable access in security settings.
 $config['smtp_host'] = (getenv('SCALAR_SMTP_HOST') ? getenv('SCALAR_SMTP_HOST') : ''); 
 $config['smtp_auth'] = true; 

--- a/system/application/libraries/SendMail.php
+++ b/system/application/libraries/SendMail.php
@@ -14,7 +14,7 @@ class SendMail {
     public function reset_password($email='', $reset_string='') {
 
     	$arr = array();
-    	$arr['from'] = 'no-reply@'.$this->domain_name();
+    	$arr['from'] = $this->from_address();
     	$arr['fromName'] = $this->install_name();
     	$arr['to'] = $email;
     	$arr['replyTo'] = $this->replyto_address();
@@ -133,7 +133,15 @@ class SendMail {
     	if (empty($install_name)) $install_name = 'Test';
     	return $install_name;
 
-    }
+	}
+	
+	private function from_address() {
+		$from_address = $this->CI->config->item('email_from_address');
+		if($from_address) {
+			return $from_address;
+		}
+		return 'no-reply@'.$this->domain_name(); // fallback if none is provided (backward compatibility)
+	}
 
     private function replyto_address() {
 


### PR DESCRIPTION
This PR adds configuration option to set the FROM address for emails, with fallback to the default `no-reply@domain_name` which is automatically determined. So this should not impact any existing users, but give extra flexibility if needed. This resolves an issue for us where we need to be able to specify the from email address.

@craigdietrich 