### PR TITLE
Update to ensure book slugs are always unique

### DIFF
--- a/system/application/config/scalar_store.sql
+++ b/system/application/config/scalar_store.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `scalar_db_books` (
   `title` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `subtitle` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `description` text COLLATE utf8_unicode_ci DEFAULT NULL,
-  `slug` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `slug` varchar(255) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
   `url_is_public` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `display_in_index` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `is_featured` tinyint(1) unsigned NOT NULL DEFAULT '0',
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS `scalar_db_content` (
   `user` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
   `created` datetime NOT NULL,
   PRIMARY KEY (`content_id`),
+  UNIQUE (`book_id`, `slug`),
   KEY `book_id` (`book_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/system/application/config/scalar_store_utf8mb4.sql
+++ b/system/application/config/scalar_store_utf8mb4.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `scalar_db_books` (
   `title` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
   `subtitle` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
   `description` text COLLATE utf8mb4_general_ci DEFAULT NULL,
-  `slug` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+  `slug` varchar(250) COLLATE utf8mb4_general_ci NOT NULL UNIQUE,
   `url_is_public` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `display_in_index` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `is_featured` tinyint(1) unsigned NOT NULL DEFAULT '0',
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS `scalar_db_content` (
   `content_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `book_id` int(10) unsigned NOT NULL DEFAULT '0',
   `recent_version_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `slug` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+  `slug` varchar(249) COLLATE utf8mb4_general_ci NOT NULL,
   `type` enum('composite','media') COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'composite',
   `is_live` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `paywall` tinyint(1) unsigned NOT NULL DEFAULT '0',
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS `scalar_db_content` (
   `user` varchar(64) COLLATE utf8mb4_general_ci NOT NULL,
   `created` datetime NOT NULL,
   PRIMARY KEY (`content_id`),
+  UNIQUE (`book_id`, `slug`),
   KEY `book_id` (`book_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/system/application/core/MY_Model.php
+++ b/system/application/core/MY_Model.php
@@ -335,31 +335,6 @@ class MY_Model extends CI_Model {
 
 	}
 
-	/**
-	 * Convert a string to safe URI slug
-	 */
-
-    public function safe_slug($slug='', $book_id=0, $content_id=0) {
-
-    	if (!$this->slug_exists($slug, $book_id, $content_id)) return $slug;
-
-    	$has_numerical_ext = is_numeric(substr($slug, strrpos($slug, '-')+1)) ? true : false;
-    	if ($has_numerical_ext) {
-    		$slug = substr($slug, 0, strrpos($slug, '-'));
-    	}
-    	
-    	$j = 1;
-    	$adj_slug = $slug.'-'.$j;
-
-    	while ($this->slug_exists($adj_slug, $book_id, $content_id)) {
-    		$j++;
-    		$adj_slug = $slug.'-'.$j;
-    	}
-
-    	return $adj_slug;
-
-    }
-
     /**
      * Return the top version for a content node
      */
@@ -429,32 +404,6 @@ class MY_Model extends CI_Model {
     	$result = $query->result();
     	$version_num = $result[0]->version_num;
     	return $version_num;
-
-    }
-
-	/**
-	 * Deterine whether a slug exists in the database
-	 */
-
-    protected function slug_exists() {
-    	
-    	list($slug, $book_id, $content_id) = array_pad(func_get_args(), 3, null);
-    	if (empty($slug)) $slug = '';
-    	if (empty($book_id)) $book_id = 0;
-    	if (empty($content_id)) $content_id = 0;
-
-     	$this->db->select('*');
-    	$this->db->from($this->pages_table);
-    	if (!empty($content_id)) $this->db->where('content_id !=', $content_id);
-    	$this->db->where('slug', $slug);
-    	$this->db->where('book_id', $book_id);
-    	$this->db->limit(1);
-    	$query = $this->db->get();
-    	if ($query->num_rows > 0) {
-    		$result = $query->result();
-    		return (int) $result[0]->content_id;
-    	}
-    	return false;
 
     }
 

--- a/system/application/models/page_model.php
+++ b/system/application/models/page_model.php
@@ -442,5 +442,55 @@ class Page_model extends MY_Model {
 
     }
 
+	/**
+	 * Convert a string to safe URI slug
+	 */
+	public function safe_slug($slug='', $book_id=0, $content_id=0) {
+
+		if (!$this->slug_exists($slug, $book_id, $content_id)) return $slug;
+
+		$has_numerical_ext = is_numeric(substr($slug, strrpos($slug, '-')+1)) ? true : false;
+		if ($has_numerical_ext) {
+			$slug = substr($slug, 0, strrpos($slug, '-'));
+		}
+
+		$j = 1;
+		$adj_slug = $slug.'-'.$j;
+
+		while ($this->slug_exists($adj_slug, $book_id, $content_id)) {
+			$j++;
+			$adj_slug = $slug.'-'.$j;
+		}
+
+		return $adj_slug;
+
+	}
+
+	/**
+	 * Deterine whether a slug exists in the database
+	 */
+
+	protected function slug_exists() {
+
+		list($slug, $book_id, $content_id) = array_pad(func_get_args(), 3, null);
+		if (empty($slug)) $slug = '';
+		if (empty($book_id)) $book_id = 0;
+		if (empty($content_id)) $content_id = 0;
+
+		$this->db->select('*');
+		$this->db->from($this->pages_table);
+		if (!empty($content_id)) $this->db->where('content_id !=', $content_id);
+		$this->db->where('slug', $slug);
+		$this->db->where('book_id', $book_id);
+		$this->db->limit(1);
+		$query = $this->db->get();
+		if ($query->num_rows > 0) {
+			$result = $query->result();
+			return (int) $result[0]->content_id;
+		}
+		return false;
+
+	}
+
 }
 ?>

--- a/system/application/views/modules/dashboard/user.php
+++ b/system/application/views/modules/dashboard/user.php
@@ -153,6 +153,9 @@ $(window).ready(function() {
 <? if (isset($_REQUEST['error']) && 'error_while_duplicating'==$_REQUEST['error']): ?>
 <tr><td colspan="2"><div class="error">There was an error attempting to duplicate the chosen book<a href="?book_id=<?=@$book_id?>&zone=user" style="float:right;">clear</a></div></td></tr>
 <? endif ?>
+<? if (isset($_REQUEST['error']) && 'error_add_book'==$_REQUEST['error']): ?>
+<tr><td colspan="2"><div class="error">Could not create book. Please try again with a different book name.<a href="?book_id=<?=@$book_id?>&zone=user" style="float:right;">remove notice</a></div></td></tr>
+<? endif ?>
 <tr>
 	<td style="vertical-align:middle;white-space:nowrap;" width="200px">Create new book</td>
 	<td style="vertical-align:middle;">

--- a/system/application/views/modules/dashboot/user.php
+++ b/system/application/views/modules/dashboot/user.php
@@ -104,6 +104,9 @@ $(document).ready(function() {
 <? if (isset($_REQUEST['error']) && 'error_while_duplicating'==$_REQUEST['error']): ?>
 <div class="alert alert-danger">There was an error attempting to duplicate the chosen book<a href="?book_id=<?=@$book_id?>&zone=user" style="float:right;">remove notice</a></div>
 <? endif ?>
+<? if (isset($_REQUEST['error']) && 'error_add_book'==$_REQUEST['error']): ?>
+    <div class="alert alert-danger">Could not create book. Please try again with a different book name.<a href="?book_id=<?=@$book_id?>&zone=user" style="float:right;">remove notice</a></div>
+<? endif ?>
 
 <div class="container-fluid user">
   <div class="row">


### PR DESCRIPTION
This PR adds database constraints that guarantee no two books can have the same slug, and updates the application logic for checking slugs and handling duplicate key errors (e.g. trying to insert a record that violates a unique constraint).

We encountered this issue while using S3 file storage. Even though this issue will probably not affect installations using the filesystem-based storage, these updates should guarantee they don't. 

Here's a complete rundown of the changes included in the PR.

**Database Changes**
- Added unique constraint to the `scalar_db_books` table on the `slug` column. This enforces the existing application logic and serves as an additional layer of protection.
- Added unique constraint to the `scalar_db_content` table on the `(book_id, slug)` columns. Given a book, the slug should be unique. This simply enforces the existing application logic and adds a layer of protection.

**Code Changes**
- Moved the `slug_exists()` and `safe_slug()` code from `MY_Model.php` into the `page_model.php`, where they are being used. Especially since the `book_model.php` simply overrides the `slug_exists()` method. The intended use is the same, but their implementations are different, so it seems best to put them in their respective classes.
- Fixed the `slug_exists()` method in `book_model.php` so that it checks the database for the existence of a slug, rather than checking the filesystem for a folder. This is the crux of the issue when using an alternative storage backend. It doesn't seem like there should be any situation where a slug folder would exist on the filesystem without a corresponding record in the database. 
- Added error handling in case the `db->insert()` method fails due to a unique key constraint error. It should never get there, because the application is checking, but just in case, an error message will be displayed to the user.

**Addendums**
- You may notice that the length of the `slug` column has been modified in  `scalar_store_utf8mb4.sql`. This was done to account for the maximum key length in MySQL MyISAM, which is 1000 bytes. The utf8 character set (actually an alias for utf8mb3), is only a 3-byte character encoding while utf8mb4 is a 4-byte character encoding. So for the `scalar_db_books` table, a length of 250 is necessary, and for `scalar_db_content`, a length of 249 is necessary since it also accounts for the book_id (`INT` = 4 bytes), which is included in the unique key.


Thoughts, questions, concerns?