### PR TITLE
Active Directory LDAP

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -81,10 +81,16 @@ $config['registration_key_msg'] = '';
 
 // LDAP authentication settings
 $config['use_ldap'] = (getenv('SCALAR_USE_LDAP') ? getenv('SCALAR_USE_LDAP') : false);  // Default: off
-$config['ldap_server'] = (getenv('SCALAR_LDAP_SERVER') ? getenv('SCALAR_LDAP_SERVER') : "ldap.server.name");
+$config['ldap_server'] = (getenv('SCALAR_LDAP_SERVER') ? getenv('SCALAR_LDAP_SERVER') : "ldap://ldap.server.name");  // Use 'ldap://' prefix even if connecting to ldaps
 $config['ldap_port'] = (getenv('SCALAR_LDAP_PORT') ? getenv('SCALAR_LDAP_PORT') : 389);
 $config['ldap_basedn'] = (getenv('SCALAR_LDAP_BASEDN') ? getenv('SCALAR_LDAP_BASEDN') : "dc=organization,dc=tld");
-$config['ldap_uname_field'] = (getenv('SCALAR_LDAP_UNAME_FIELD') ? getenv('SCALAR_LDAP_UNAME_FIELD') : "uid");
+$config['ldap_uname_field'] = (getenv('SCALAR_LDAP_UNAME_FIELD') ? getenv('SCALAR_LDAP_UNAME_FIELD') : "uid");  // Default 'uid', For AD use 'sAMAccountName'
+$config['ldap_filter'] = (getenv('SCALAR_LDAP_FILTER') ? getenv('SCALAR_LDAP_FILTER') : '');
+
+// Active Directory LDAP settings
+$config['use_ad_ldap'] = (getenv('SCALAR_USE_AD_LDAP') ? getenv('SCALAR_USE_AD_LDAP') : false);  // Default: off
+$config['ad_bind_user'] = (getenv('SCALAR_AD_BIND_USER') ? getenv('SCALAR_AD_BIND_USER') : "");  // Use LDAP Distinguished Name
+$config['ad_bind_pass'] = (getenv('SCALAR_AD_BIND_PASS') ? getenv('SCALAR_AD_BIND_PASS') : "");
 
 // Emails
 $config['email_replyto_address'] = (getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') ? getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') : ''); 

--- a/system/application/models/user_model.php
+++ b/system/application/models/user_model.php
@@ -172,9 +172,9 @@ class User_model extends MY_Model {
         $ad_bind_user = $this->config->item('ad_bind_user');
         $ad_bind_pass = $this->config->item('ad_bind_pass');
 
-	if ( strlen(trim($password)) == 0 ) {
+        if ( strlen(trim($password)) == 0 ) {
            return false;
-	}
+        }
 
         $ldapCon = ldap_connect( $ldap_host, $ldap_port );
         if ( !$ldapCon) {


### PR DESCRIPTION
Additions to allow compatibility with AD LDAP. 

In user model:
- If AD is enabled, sets LDAP_OPT_REFERRALS option
- If AD is enabled, binds with bind account prior to ldap_search (AD LDAP does not accept anonymous)
- Adds ability to filter access by security group (both standard and AD LDAP)

In local settings:
- Additional options added to allow enabling/disabling AD settings and providing the needed info
- Additional commenting on LDAP options to assist with setup confusion

Example config entries for AD connecting over LDAPS and limited to "Scalar Users" group for access:

`
// LDAP authentication settings
$config['use_ldap'] = (getenv('SCALAR_USE_LDAP') ? getenv('SCALAR_USE_LDAP') : true);  // Default: off
$config['ldap_server'] = (getenv('SCALAR_LDAP_SERVER') ? getenv('SCALAR_LDAP_SERVER') : "ldap://company.domain.com"); // Use 'ldap://' prefix even if connecting to ldaps
$config['ldap_port'] = (getenv('SCALAR_LDAP_PORT') ? getenv('SCALAR_LDAP_PORT') : 636);
$config['ldap_basedn'] = (getenv('SCALAR_LDAP_BASEDN') ? getenv('SCALAR_LDAP_BASEDN') : "DC=company,DC=domain,DC=com");
$config['ldap_uname_field'] = (getenv('SCALAR_LDAP_UNAME_FIELD') ? getenv('SCALAR_LDAP_UNAME_FIELD') : "sAMAccountName"); // Default 'uid', For AD use 'sAMAccountName'
$config['ldap_filter'] = (getenv('SCALAR_LDAP_FILTER') ? getenv('SCALAR_LDAP_FILTER') : '(memberOf=CN=Scalar Users,OU=Groups,DC=company,DC=domain,DC=com)');

// Active Directory LDAP settings
$config['use_ad_ldap'] = (getenv('SCALAR_USE_AD_LDAP') ? getenv('SCALAR_USE_AD_LDAP') : true);  // Default: off
$config['ad_bind_user'] = (getenv('SCALAR_AD_BIND_USER') ? getenv('SCALAR_AD_BIND_USER') : "CN=Service Account,OU=Users,DC=company,DC=domain,DC=com"); // Use LDAP Distinguished Name
$config['ad_bind_pass'] = (getenv('SCALAR_AD_BIND_PASS') ? getenv('SCALAR_AD_BIND_PASS') : "serviceAccountPassword");
`
