### PR TITLE
Local settings override

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -126,7 +126,7 @@ $config['override_edit_page_default_tab'] = array(
 );
 
 // Load local_settings_custom.php, if it exists, to allow overrides via a separate file.
-if (file_exists('local_settings_custom.php')) { include 'local_settings_custom.php'; }
+if (file_exists(dirname(__FILE__).'/local_settings_custom.php')) { include 'local_settings_custom.php'; }
 
 //EOF
 

--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -125,6 +125,9 @@ $config['override_edit_page_default_tab'] = array(
   )
 );
 
+// Load local_settings_custom.php, if it exists, to allow overrides via a separate file.
+if (file_exists('local_settings_custom.php')) { include 'local_settings_custom.php'; }
+
 //EOF
 
 ?>


### PR DESCRIPTION
Hi folk!  In our environment, we update/install Scalar via git pulls in an automated way.  Scalar's upgrade process seems to be built more around doing updates by hand.  I've added a fairly simple tweak to local_settings.php that calls, if it exists, a local_settings_custom.php file in the same directory that we can edit to avoid git update conflicts.  It doesn't hurt anything if it's not there.  =)