### PR TITLE
Mirador viewer max-height

### DIFF
--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5534,6 +5534,8 @@ function YouTubeGetID(url){
 
 			this.parentView.layoutMediaObject();
 			this.parentView.removeLoadingMessage();
+                        // make sure mirador doesn't overflow its bounds
+                        $('.mirador-viewer').css('max-height', $('.mediaContainer').css('max-height'));
 
 			return;
 		}


### PR DESCRIPTION
This PR resolves the issue of Mirador overflowing its mediaElement bounds by:

- Setting the `max-height` of `.mirador-viewer` to the `max-height` of `.mediaContainer`

I tested it locally, and it should resolve the issues you pointed out @eloyer 

Thanks for pointing it out. I don't know scalar well enough to have noticed the problem :/