### PR TITLE
Make sure each mirador instance gets unique identifier

### DIFF
--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5517,8 +5517,7 @@ function YouTubeGetID(url){
 	 */
 	jQuery.MiradorObjectView = function(model, parentView) {
 
-    var me = this;
-
+		var me = this;
 		this.model = model;  					// instance of the model
 		this.parentView = parentView;   		// primary view for the media element
 		this.isLiquid = true;					// media will expand to fill available space
@@ -5528,21 +5527,17 @@ function YouTubeGetID(url){
 		 */
 		jQuery.MiradorObjectView.prototype.createObject = function() {
 
-			var approot = $('link#approot').attr('href');
-
-			let m3Instances = $('.m3');
-			let miradorId = m3Instances.length;
-			this.mediaObject = $( `<div class="mediaObject m3" id="mirador-${miradorId}"></div>`).appendTo( this.parentView.mediaContainer );
+			this.mediaObject = $( `<div class="mediaObject" id="mirador-${me.model.id}"></div>`).appendTo( this.parentView.mediaContainer );
 
             var miradorInstance = Mirador.viewer({
-                id: `mirador-${miradorId}`,
+                id: `mirador-${me.model.id}`,
                 windows: [{ manifestId: this.model.node.current.sourceFile }]
             });
 
 			this.parentView.layoutMediaObject();
 			this.parentView.removeLoadingMessage();
-            // make sure mirador doesn't overflow its bounds
-            $('.mirador-viewer').css('max-height', $('.mediaContainer').css('max-height'));
+			// make sure mirador doesn't overflow its bounds
+			$('.mirador-viewer', this.mediaObject).css('max-height', $(this.parentView.mediaContainer).css('max-height'));
 
 			return;
 		}
@@ -5561,8 +5556,8 @@ function YouTubeGetID(url){
 		 * @param {Number} height		The new height of the media.
 		 */
 		jQuery.MiradorObjectView.prototype.resize = function(width, height) {
-			$('.m3').width(Math.round(width));
-			$('.m3').height(Math.round(height));
+			$(`#mirador-${me.model.id}`).width(Math.round(width));
+			$(`#mirador-${me.model.id}`).height(Math.round(height));
 		}
 
 	}

--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -1147,9 +1147,9 @@ function YouTubeGetID(url){
 						case 'tiledImage':
 							this.mediaObjectView = new $.DeepZoomImageObjectView(this.model, this);
 						break;
-                                                case 'manifest':
-                                                        this.mediaObjectView = new $.MiradorObjectView(this.model, this);
-                                                break;
+                        case 'manifest':
+                            this.mediaObjectView = new $.MiradorObjectView(this.model, this);
+                        break;
 						case 'audio':
 						if (this.model.mediaSource.name == 'SoundCloud') {
 							this.mediaObjectView = new $.SoundCloudAudioObjectView(this.model, this);
@@ -5530,17 +5530,19 @@ function YouTubeGetID(url){
 
 			var approot = $('link#approot').attr('href');
 
-			this.mediaObject = $( '<div class="mediaObject" id="mirador"></div>' ).appendTo( this.parentView.mediaContainer );
+			let m3Instances = $('.m3');
+			let miradorId = m3Instances.length;
+			this.mediaObject = $( `<div class="mediaObject m3" id="mirador-${miradorId}"></div>`).appendTo( this.parentView.mediaContainer );
 
-      var miradorInstance = Mirador.viewer({
-          id: 'mirador',
-          windows: [{ manifestId: this.model.node.current.sourceFile }]
-      });
+            var miradorInstance = Mirador.viewer({
+                id: `mirador-${miradorId}`,
+                windows: [{ manifestId: this.model.node.current.sourceFile }]
+            });
 
 			this.parentView.layoutMediaObject();
 			this.parentView.removeLoadingMessage();
-      // make sure mirador doesn't overflow its bounds
-      $('.mirador-viewer').css('max-height', $('.mediaContainer').css('max-height'));
+            // make sure mirador doesn't overflow its bounds
+            $('.mirador-viewer').css('max-height', $('.mediaContainer').css('max-height'));
 
 			return;
 		}
@@ -5559,8 +5561,8 @@ function YouTubeGetID(url){
 		 * @param {Number} height		The new height of the media.
 		 */
 		jQuery.MiradorObjectView.prototype.resize = function(width, height) {
-			$('#mirador').width(Math.round(width));
-			$('#mirador').height(Math.round(height));
+			$('.m3').width(Math.round(width));
+			$('.m3').height(Math.round(height));
 		}
 
 	}


### PR DESCRIPTION
This PR should resolve issues observed when instantiating more than one mirador viewer on a page. It doe so by:

- Checking the page for the number of mirador instances on the page
- Using the check to create a `miradorId`
- Use the `miradorId` in the media object div, as well as the Mirador.viewer