### PR TITLE
Update amazon-s3-php-class to latest version to support PHP 7.4

### DIFF
--- a/system/application/libraries/amazon-s3-php-class/README.md
+++ b/system/application/libraries/amazon-s3-php-class/README.md
@@ -14,15 +14,6 @@ Statically (e,g; S3::getObject(...)):
 S3::setAuth($awsAccessKey, $awsSecretKey);
 ```
 
-### AWS V4 Signature
-
-```php
-$s3->setSignatureVersion('v4);
-```
-Or statically
-```php
-S3::setSignatureVersion('v4');
-```
 
 ### Object Operations
 
@@ -107,19 +98,3 @@ Delete an empty bucket:
 S3::deleteBucket($bucketName)
 ```
 
-### Progress Function
-
-Add a progress function when S3 downloading / uploading 
-
-```php
-S3::setProgressFunction('progress');
-
-function progress($resource,$download_size, $downloaded, $upload_size, $uploaded)
-{
-    if($download_size > 0)
-         echo $downloaded / $download_size  * 100;
-    ob_flush();
-    flush();
-    sleep(1); // just to see effect
-}
-```

--- a/system/application/libraries/amazon-s3-php-class/S3.php
+++ b/system/application/libraries/amazon-s3-php-class/S3.php
@@ -209,15 +209,6 @@ class S3
 	public static $progressFunction = null;
 
 	/**
-	 * AWS Signature Version
-	 *
-	 * @var string
-	 * @acess public
-	 * @static
-	 */
-	public static $signVer = 'v2';
-
-	/**
 	* Constructor - if you're not using the class statically
 	*
 	* @param string $accessKey Access key
@@ -271,8 +262,11 @@ class S3
 		$region = self::$region;
 
 		// parse region from endpoint if not specific
-		if (empty($region)) {
-			if (preg_match("/s3[.-](?:website-|dualstack\.)?(.+)\.amazonaws\.com/i",self::$endpoint,$match) !== 0 && strtolower($match[1]) !== "external-1") {
+		if (empty($region)) 
+		{
+			if (preg_match("/s3[.-](?:website-|dualstack\.)?(.+)\.amazonaws\.com/i", self::$endpoint, $match) !== 0 
+			&& strtolower($match[1]) !== "external-1") 
+			{
 				$region = $match[1];
 			}		
 		}
@@ -403,17 +397,6 @@ class S3
 		return false;
 	}
 
-
-	/**
-	* Set Signature Version
-	*
-	* @param string $version of signature ('v4' or 'v2')
-	* @return void
-	*/
-	public static function setSignatureVersion($version = 'v2')
-	{
-		self::$signVer = $version;
-	}
 
 
 	/**
@@ -2000,109 +1983,100 @@ class S3
 
 	/**
 	* Generate the headers for AWS Signature V4
+	* 
 	* @internal Used by S3Request::getResponse()
-	* @param array $aheaders amzHeaders 
+	* @param array $amzHeaders
 	* @param array $headers
-	* @param string $method 
+	* @param string $method
 	* @param string $uri
-	* @param string $data
-	* @return array $headers
+	* @param array $parameters
+	* @return array
 	*/
-	public static function __getSignatureV4($aHeaders, $headers, $method='GET', $uri='', $data = '')
+	public static function __getSignatureV4($amzHeaders, $headers, $method, $uri, $parameters)
 	{		
 		$service = 's3';
 		$region = S3::getRegion();
-		
-		$algorithm = 'AWS4-HMAC-SHA256';
-		$amzHeaders = array();
-		$amzRequests = array();
-		
-		$amzDate =  gmdate( 'Ymd\THis\Z' );
-		$amzDateStamp = gmdate( 'Ymd' );
 
-		// amz-date ISO8601 format ? for aws request		
-		$amzHeaders['x-amz-date'] = $amzDate;
+		$algorithm = 'AWS4-HMAC-SHA256';
+		$combinedHeaders = array();
+
+		$amzDateStamp = substr($amzHeaders['x-amz-date'], 0, 8);
 
 		// CanonicalHeaders
-		foreach ( $headers as $k => $v ) {
-			$amzHeaders[ strtolower( $k ) ] = trim( $v );
-		} 
-		foreach ( $aHeaders as $k => $v ) {
-			$amzHeaders[ strtolower( $k ) ] = trim( $v );
-		} 
-		uksort( $amzHeaders, 'strcmp' );
+		foreach ($headers as $k => $v)
+			$combinedHeaders[strtolower($k)] = trim($v);
+		foreach ($amzHeaders as $k => $v) 
+			$combinedHeaders[strtolower($k)] = trim($v);
+		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));
 
-		// payload
-		$payloadHash = isset($amzHeaders['x-amz-content-sha256']) ? $amzHeaders['x-amz-content-sha256'] :  hash('sha256', $data);
+		// Convert null query string parameters to strings and sort
+		$parameters = array_map('strval', $parameters); 
+		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
+		$queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
 
-		// parameters
-		$parameters = array();
-		if (strpos($uri, '?')) {
-			list ($uri, $query_str) = @explode("?", $uri);
-			parse_str($query_str, $parameters);
-		}
+		// Payload
+		$amzPayload = array($method);
 
-		// CanonicalRequests
-		$amzRequests[] = $method;
-		$uriQmPos = strpos($uri, '?'); 
-		$amzRequests[] = ($uriQmPos === false ? $uri : substr($uri, 0, $uriQmPos));
-		$amzRequests[] = http_build_query($parameters);
+		$qsPos = strpos($uri, '?');
+		$amzPayload[] = ($qsPos === false ? $uri : substr($uri, 0, $qsPos));
+
+		$amzPayload[] = $queryString;
 		// add header as string to requests
-		foreach ( $amzHeaders as $k => $v ) {
-			$amzRequests[] = $k . ':' . $v;
+		foreach ($combinedHeaders as $k => $v ) 
+		{
+			$amzPayload[] = $k . ':' . $v;
 		}
 		// add a blank entry so we end up with an extra line break
-		$amzRequests[] = '';
+		$amzPayload[] = '';
 		// SignedHeaders
-		$amzRequests[] = implode( ';', array_keys( $amzHeaders ) );
+		$amzPayload[] = implode(';', array_keys($combinedHeaders));
 		// payload hash
-		$amzRequests[] = $payloadHash;
+		$amzPayload[] = $amzHeaders['x-amz-content-sha256'];
 		// request as string
-		$amzRequestStr = implode("\n", $amzRequests);
-		
+		$amzPayloadStr = implode("\n", $amzPayload);
+
 		// CredentialScope
-		$credentialScope = array();
-		$credentialScope[] = $amzDateStamp;
-		$credentialScope[] = $region;
-		$credentialScope[] = $service;
-		$credentialScope[] = 'aws4_request';
+		$credentialScope = array($amzDateStamp, $region, $service, 'aws4_request');
 
 		// stringToSign
-		$stringToSign = array();
-		$stringToSign[] = $algorithm;
-		$stringToSign[] = $amzDate;
-		$stringToSign[] = implode('/', $credentialScope);
-		$stringToSign[] =  hash('sha256', $amzRequestStr);
-		// as string
-		$stringToSignStr = implode("\n", $stringToSign);
+		$stringToSignStr = implode("\n", array($algorithm, $amzHeaders['x-amz-date'], 
+		implode('/', $credentialScope), hash('sha256', $amzPayloadStr)));
 
 		// Make Signature
 		$kSecret = 'AWS4' . self::$__secretKey;
-		$kDate = hash_hmac( 'sha256', $amzDateStamp, $kSecret, true );
-		$kRegion = hash_hmac( 'sha256', $region, $kDate, true );
-		$kService = hash_hmac( 'sha256', $service, $kRegion, true );
-		$kSigning = hash_hmac( 'sha256', 'aws4_request', $kService, true );
-		
-		$signature = hash_hmac( 'sha256', $stringToSignStr, $kSigning );
+		$kDate = hash_hmac('sha256', $amzDateStamp, $kSecret, true);
+		$kRegion = hash_hmac('sha256', $region, $kDate, true);
+		$kService = hash_hmac('sha256', $service, $kRegion, true);
+		$kSigning = hash_hmac('sha256', 'aws4_request', $kService, true);
 
-		$authorization = array(
-			'Credential=' . self::$__accessKey . '/' . implode( '/', $credentialScope ),
-			'SignedHeaders=' . implode( ';', array_keys( $amzHeaders ) ),
+		$signature = hash_hmac('sha256', $stringToSignStr, $kSigning);
+
+		return $algorithm . ' ' . implode(',', array(
+			'Credential=' . self::$__accessKey . '/' . implode('/', $credentialScope),
+			'SignedHeaders=' . implode(';', array_keys($combinedHeaders)),
 			'Signature=' . $signature,
-		);
-
-		$authorizationStr = $algorithm . ' ' . implode( ',', $authorization );
-
-		$resultHeaders = array( 
-			'X-AMZ-DATE' => $amzDate,			
-			'Authorization' => $authorizationStr
-		);
-		if (!isset($aHeaders['x-amz-content-sha256'])) $resultHeaders['x-amz-content-sha256'] = $payloadHash;
-
-		return $resultHeaders;
+		));
 	}
 
 
+	/**
+	* Sort compare for meta headers
+	*
+	* @internal Used to sort x-amz meta headers
+	* @param string $a String A
+	* @param string $b String B
+	* @return integer
+	*/
+	private static function __sortMetaHeadersCmp($a, $b)
+	{
+		$lenA = strlen($a);
+		$lenB = strlen($b);
+		$minLen = min($lenA, $lenB);
+		$ncmp = strncmp($a, $b, $minLen);
+		if ($lenA == $lenB) return $ncmp;
+		if (0 == $ncmp) return $lenA < $lenB ? -1 : 1;
+		return $ncmp;
+	}
 }
 
 /**
@@ -2223,16 +2197,10 @@ final class S3Request
 	*/
 	function __construct($verb, $bucket = '', $uri = '', $endpoint = 's3.amazonaws.com')
 	{
-		
 		$this->endpoint = $endpoint;
 		$this->verb = $verb;
 		$this->bucket = $bucket;
 		$this->uri = $uri !== '' ? '/'.str_replace('%2F', '/', rawurlencode($uri)) : '/';
-
-		//if ($this->bucket !== '')
-		//	$this->resource = '/'.$this->bucket.$this->uri;
-		//else
-		//	$this->resource = $this->uri;
 
 		if ($this->bucket !== '')
 		{
@@ -2243,6 +2211,7 @@ final class S3Request
 			}
 			else
 			{
+				// Old format, deprecated by AWS - removal scheduled for September 30th, 2020
 				$this->headers['Host'] = $this->endpoint;
 				$this->uri = $this->uri;
 				if ($this->bucket !== '') $this->uri = '/'.$this->bucket.$this->uri;
@@ -2330,8 +2299,6 @@ final class S3Request
 		}
 		$url = (S3::$useSSL ? 'https://' : 'http://') . ($this->headers['Host'] !== '' ? $this->headers['Host'] : $this->endpoint) . $this->uri;
 
-		//var_dump('bucket: ' . $this->bucket, 'uri: ' . $this->uri, 'resource: ' . $this->resource, 'url: ' . $url);
-
 		// Basic setup
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_USERAGENT, 'S3/php');
@@ -2361,56 +2328,46 @@ final class S3Request
 		}
 
 		// Headers
-		$headers = array(); $amz = array();
-		foreach ($this->amzHeaders as $header => $value)
-			if (strlen($value) > 0) $headers[] = $header.': '.$value;
-		foreach ($this->headers as $header => $value)
-			if (strlen($value) > 0) $headers[] = $header.': '.$value;
-
-		// Collect AMZ headers for signature
-		foreach ($this->amzHeaders as $header => $value)
-			if (strlen($value) > 0) $amz[] = strtolower($header).':'.$value;
-
-		// AMZ headers must be sorted
-		if (sizeof($amz) > 0)
-		{
-			//sort($amz);
-			usort($amz, array(&$this, '__sortMetaHeadersCmp'));
-			$amz = "\n".implode("\n", $amz);
-		} else $amz = '';
-
+		$httpHeaders = array(); 
 		if (S3::hasAuth())
 		{
 			// Authorization string (CloudFront stringToSign should only contain a date)
 			if ($this->headers['Host'] == 'cloudfront.amazonaws.com')
-				$headers[] = 'Authorization: ' . S3::__getSignature($this->headers['Date']);
+			{
+				# TODO: Update CloudFront authentication
+				foreach ($this->amzHeaders as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				foreach ($this->headers as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				$httpHeaders[] = 'Authorization: ' . S3::__getSignature($this->headers['Date']);
+			}
 			else
 			{
-				if (S3::$signVer == 'v2')
-				{
-					$headers[] = 'Authorization: ' . S3::__getSignature(
-						$this->verb."\n".
-						$this->headers['Content-MD5']."\n".
-						$this->headers['Content-Type']."\n".
-						$this->headers['Date'].$amz."\n".
-						$this->resource
-					);
-				} else {
-					$amzHeaders = S3::__getSignatureV4(
-						$this->amzHeaders,
-						$this->headers, 
-						$this->verb, 
-						$this->uri,
-						$this->data
-					);
-					foreach ($amzHeaders as $k => $v) {
-						$headers[] = $k .': '. $v;
-					}
-				}
+				$this->amzHeaders['x-amz-date'] = gmdate('Ymd\THis\Z');
+
+				if (!isset($this->amzHeaders['x-amz-content-sha256'])) 
+					$this->amzHeaders['x-amz-content-sha256'] = hash('sha256', $this->data);
+
+				foreach ($this->amzHeaders as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				foreach ($this->headers as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				$httpHeaders[] = 'Authorization: ' . S3::__getSignatureV4(
+					$this->amzHeaders,
+					$this->headers, 
+					$this->verb, 
+					$this->uri,
+					$this->parameters
+				);
+
 			}
 		}
 
-		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $httpHeaders);
 		curl_setopt($curl, CURLOPT_HEADER, false);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
 		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, '__responseWriteCallback'));
@@ -2491,24 +2448,6 @@ final class S3Request
 		return $this->response;
 	}
 
-	/**
-	* Sort compare for meta headers
-	*
-	* @internal Used to sort x-amz meta headers
-	* @param string $a String A
-	* @param string $b String B
-	* @return integer
-	*/
-	private function __sortMetaHeadersCmp($a, $b)
-	{
-		$lenA = strpos($a, ':');
-		$lenB = strpos($b, ':');
-		$minLen = min($lenA, $lenB);
-		$ncmp = strncmp($a, $b, $minLen);
-		if ($lenA == $lenB) return $ncmp;
-		if (0 == $ncmp) return $lenA < $lenB ? -1 : 1;
-		return $ncmp;
-	}
 
 	/**
 	* CURL write callback
@@ -2562,16 +2501,17 @@ final class S3Request
 			$data = trim($data);
 			if (strpos($data, ': ') === false) return $strlen;
 			list($header, $value) = explode(': ', $data, 2);
-			if ($header == 'Last-Modified')
+			$header = strtolower($header);
+			if ($header == 'last-modified')
 				$this->response->headers['time'] = strtotime($value);
-			elseif ($header == 'Date')
+			elseif ($header == 'date')
 				$this->response->headers['date'] = strtotime($value);
-			elseif ($header == 'Content-Length')
+			elseif ($header == 'content-length')
 				$this->response->headers['size'] = (int)$value;
-			elseif ($header == 'Content-Type')
+			elseif ($header == 'content-type')
 				$this->response->headers['type'] = $value;
-			elseif ($header == 'ETag')
-				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
+			elseif ($header == 'etag')
+				$this->response->headers['hash'] = $value[0] == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
 				$this->response->headers[$header] = $value;
 		}

--- a/system/application/libraries/amazon-s3-php-class/example.php
+++ b/system/application/libraries/amazon-s3-php-class/example.php
@@ -35,9 +35,6 @@ if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
 // Instantiate the class
 $s3 = new S3(awsAccessKey, awsSecretKey);
 
-// using v4 signature
-$s3->setSignatureVersion('v4');
-
 // List your buckets:
 echo "S3::listBuckets(): ".print_r($s3->listBuckets(), 1)."\n";
 


### PR DESCRIPTION
This PR updates the [amazon-s3-php-class](https://github.com/tpyo/amazon-s3-php-class) library to the latest version, which includes a fix for [deprecated syntax for arrays in PHP 7.4](https://wiki.php.net/rfc/deprecate_curly_braces_array_access). 

This is related to issues #145 and #146 and should resolve the S3 upload errors.

@craigdietrich @eloyer 