### PR TITLE
Add configuration to enable/disable LDAP referrals

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -101,6 +101,12 @@ $config['ldap_filter'] = (getenv('SCALAR_LDAP_FILTER') ? getenv('SCALAR_LDAP_FIL
 $config['use_ad_ldap'] = (getenv('SCALAR_USE_AD_LDAP') ? getenv('SCALAR_USE_AD_LDAP') : false);  // Default: off
 $config['ad_bind_user'] = (getenv('SCALAR_AD_BIND_USER') ? getenv('SCALAR_AD_BIND_USER') : "");  // Use LDAP Distinguished Name
 $config['ad_bind_pass'] = (getenv('SCALAR_AD_BIND_PASS') ? getenv('SCALAR_AD_BIND_PASS') : "");
+   // explicity enable/disable ldap referrals. Expects 1 or 0. If not set, defaults to previous behavior, which is:
+   // if AD is active, turn referrals OFF, otherwise, don't set the value
+if( getenv('SCALAR_SET_LDAP_REFERRALS') )
+	$config['set_ldap_referrals'] = getenv('SCALAR_SET_LDAP_REFERRALS');
+else
+	$config['set_ldap_referrals'] = ($config['use_ad_ldap']) ? 0 : null;	
 
 // Emails
 $config['email_replyto_address'] = (getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') ? getenv('SCALAR_EMAIL_REPLYTO_ADDRESS') : ''); 

--- a/system/application/models/user_model.php
+++ b/system/application/models/user_model.php
@@ -169,6 +169,7 @@ class User_model extends MY_Model {
         $uname_field = $this->config->item('ldap_uname_field');
         $filter = $this->config->item('ldap_filter');
         $use_ad = $this->config->item('use_ad_ldap');
+        $set_referrals = $this->config->item('set_ldap_referrals');
         $ad_bind_user = $this->config->item('ad_bind_user');
         $ad_bind_pass = $this->config->item('ad_bind_pass');
 
@@ -183,9 +184,8 @@ class User_model extends MY_Model {
 
         ldap_set_option($ldapCon, LDAP_OPT_PROTOCOL_VERSION, 3);
 
-        if ( $use_ad === true ) {
-            ldap_set_option($ldapCon, LDAP_OPT_REFERRALS, 0);
-        }
+        if( $set_referrals !== null )
+            ldap_set_option($ldapCon, LDAP_OPT_REFERRALS, (int) $set_referrals );
 
         if ( !ldap_start_tls($ldapCon) ) {
             throw new Exception('Unable to start TLS on LDAP connection');


### PR DESCRIPTION
My brief research indicates that referrals should be on sometimes, off sometimes based on the server configuration. So I added the ability to turn them on _or_ off. 

If the new config item is not set, the previous behavior is maintained: referrals will be turned OFF if ActiveDirectory is enabled, otherwise nothing. 

Closes #143 