### PR TITLE
Add Harvard Art Museums xsl archive

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -79,6 +79,9 @@ $config['dpla_key'] = (getenv('SCALAR_DPLA_KEY') ? getenv('SCALAR_DPLA_KEY') : '
 // New York Public Library key
 $config['nypl_key'] = (getenv('SCALAR_NYPL_KEY') ? getenv('SCALAR_NYPL_KEY') : '');
 
+// Harvard Art Museums api key
+$config['harvard_art_museums_key'] = (getenv('HAM_API_KEY') ? getenv('HAM_API_KEY') : '');
+
 // Custom message for the book index page (leave blank for no message)		   
 $config['index_msg'] = '';
 

--- a/system/application/controllers/api.php
+++ b/system/application/controllers/api.php
@@ -223,6 +223,9 @@ Class Api extends CI_Controller {
 		//parse data
 		$this->_load_update_data();
 
+		// if the content is a iiif resource, try to get the thumbnail & dc:terms metadata
+		$this->_load_iiif_data();
+
 		//validate and save the content entry
 		$save_content = $this->_array_remap_content_update();
 		if (!$this->users->is_a($this->user->relationship,'reviewer')&&!$this->pages->is_owner($this->user->user_id,$this->data['content_id'])) {
@@ -285,7 +288,9 @@ Class Api extends CI_Controller {
 			$iiif_metadata_array = $this->_get_IIIF_metadata($this->data['scalar:url']);
 			if($iiif_metadata_array !== false){
 				foreach ($iiif_metadata_array as $key => $value){
-					$this->data[$key] = $value;
+					if (empty($this->data[$key])){
+						$this->data[$key] = $value;
+					}
 				}
 			}
 		}
@@ -575,12 +580,12 @@ Class Api extends CI_Controller {
 		return $save;
 	}
 
-        /**
+	/**
 	* _get_IIIF_metadata takes IIIF manifest url, and returns associative array of metadata.
 	* Otherwise, it will return False
 	* @return array
 	*/
-        private function _get_IIIF_metadata($url=''){
+	private function _get_IIIF_metadata($url=''){
 		$ontologies = $this->config->item('ontologies');
         $dc_check_fields = array_diff($ontologies['dcterms'], array('title', 'description', 'license'));
 		$formated_check_fields = array_combine($dc_check_fields, array_map('strtolower', $dc_check_fields));

--- a/system/application/rdf/xsl/archives.rdf
+++ b/system/application/rdf/xsl/archives.rdf
@@ -157,5 +157,14 @@
 		<scalar:getStr><![CDATA[q=$1&publicDomainOnly=true&per_page=50&page=$2]]></scalar:getStr>
 		<scalar:header>Authorization: Token token=$api_key</scalar:header>
 	</rdf:Description>	
+
+	<rdf:Description rdf:about="https://api.harvardartmuseums.org/object">
+		<rdf:type rdf:resource="scalar:External" />
+		<dc:title>Harvard Art Museums</dc:title>
+		<dcterms:description><![CDATA[Look up resources in the Harvard Art Museums Api ]]></dcterms:description>
+		<scalar:XSL rdf:resource="{$base_url}rdf/xsl/harvard_art_museums.xsl" />
+		<scalar:getStr><![CDATA[q=title:$1&apikey=$api_key]]></scalar:getStr>
+		<dcterms:hasFormat>json</dcterms:hasFormat>
+	</rdf:Description>
 	
 </rdf:RDF>	

--- a/system/application/rdf/xsl/harvard_art_museums.xsl
+++ b/system/application/rdf/xsl/harvard_art_museums.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:base="http://example.com/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:scalar="http://vectorsdev.usc.edu/scalar/elements/1.0/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:art="http://simile.mit.edu/2003/10/ontologies/artstor#"
+    xmlns:sioc="http://rdfs.org/sioc/ns#">
+
+    <!-- Harvard Art Museums import XSL version 1.0 by Tylor Dodge -->
+
+    <xsl:variable name="archiveName">
+        <xsl:text>Harvard Art Museums</xsl:text>
+    </xsl:variable>
+
+    <!-- Templates -->
+
+    <xsl:template match="/">
+        <rdf:RDF>
+            <xsl:apply-templates select="//node/node[images]" />
+        </rdf:RDF>
+    </xsl:template>
+
+    <xsl:template match="*"></xsl:template>
+
+    <xsl:template match="//node/node[images]">
+        <rdf:Description rdf:about="{url}">
+            <art:thumbnail rdf:resource="{concat(images/node[1]/iiifbaseuri, '/full/!225,225/0/default.jpg')}" />
+            <art:filename><xsl:value-of select="concat(seeAlso/node[1]/id, '?iiif-manifest=1')" /></art:filename>
+            <dcterms:title><xsl:value-of select="title" /></dcterms:title>
+            <dcterms:description><xsl:value-of select="description" /></dcterms:description>
+            <dcterms:source><xsl:value-of select="$archiveName"/></dcterms:source>
+            <dcterms:accrualMethod><xsl:value-of select="accessionmethod" /></dcterms:accrualMethod>
+            <dcterms:available><xsl:value-of select="accessionyear" /></dcterms:available>
+            <dcterms:medium><xsl:value-of select="medium" /></dcterms:medium>
+            <dcterms:format><xsl:value-of select="dimensions" /></dcterms:format>
+            <dcterms:provenance><xsl:value-of select="provenance" /></dcterms:provenance>
+            <dcterms:rights><xsl:value-of select="copyright" /></dcterms:rights>
+            <dcterms:rightsHolder><xsl:value-of select="creditline" /></dcterms:rightsHolder>
+            <dcterms:type><xsl:value-of select="classification" /></dcterms:type>
+            <xsl:if test="count(places/node/displayname) > 0">
+                <dcterms:spatial><xsl:value-of select="concat(places/node/displayname, ' (', places/node/type, ')')"/></dcterms:spatial>
+            </xsl:if>
+            <xsl:if test="count(culture) > 0">
+                <dcterms:coverage><xsl:value-of select="concat('Culture:', culture)" /></dcterms:coverage>
+            </xsl:if>
+        </rdf:Description>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/system/application/views/arbors/html5_RDFa/js/form-validation.js
+++ b/system/application/views/arbors/html5_RDFa/js/form-validation.js
@@ -136,9 +136,9 @@ function validate_edit_form(form, no_action) {
 				return false;
 			}
 		}
-                if ($('#media_file_url_iiif')) {
-                    $('#media_file_url_iiif').val = $('#media_file_url_iiif').checked === true ? 1 : 0;
-                }
+		if ($('#media_file_url_iiif')) {
+			$('#media_file_url_iiif').val = $('#media_file_url_iiif').checked === true ? 1 : 0;
+		}
 		return true;
 	};
 
@@ -258,10 +258,10 @@ function send_form($form, additional_values, success, redirect_url) {
 		}
 	}
 
-        // if user indicates the url is a iiif manifest
-        if (values['iiif-url'] && values['iiif-url'] === "on" && values['scalar:url'].indexOf('?iiif-manifest=1') === -1) {
-            values['scalar:url'] = values['scalar:url'].concat('?iiif-manifest=1');
-        }
+	// if user indicates the url is a iiif manifest
+	if (values['iiif-url'] && values['iiif-url'] === "on" && values['scalar:url'].indexOf('?iiif-manifest=1') === -1) {
+		values['scalar:url'] = values['scalar:url'].concat('?iiif-manifest=1');
+	}
 
 	if ('undefined'==typeof(success) || null==success) {
 		success = function(version) {

--- a/system/application/views/melons/cantaloupe/edit.php
+++ b/system/application/views/melons/cantaloupe/edit.php
@@ -914,7 +914,7 @@ if($currentRole == 'commentator'){
 	<div class="checkbox">
 		<label>
 			<input type="checkbox" id="media_file_url_iiif" name="iiif-url" <?=strpos($file_url, '?iiif-manifest=1')?'checked':''?> />
-			Is IIIF manifest
+			Is IIIF Manifest
 	    </label>
 	</div>
 </div>

--- a/system/application/views/melons/cantaloupe/js/scalarheader.jquery.js
+++ b/system/application/views/melons/cantaloupe/js/scalarheader.jquery.js
@@ -338,6 +338,7 @@ getPropertyValue:function(a){return this[a]||""},item:function(){},removePropert
                                                                 '<li><a href="' + base.get_param(scalarapi.model.urlPrefix + 'import/omeka_s') + '">Omeka S sites</a></li>'+
                                                                 '<li><a href="' + base.get_param(scalarapi.model.urlPrefix + 'import/soundcloud') + '">SoundCloud</a></li>'+
                                                                 '<li><a href="' + base.get_param(scalarapi.model.urlPrefix + 'import/youtube') + '">YouTube</a></li>'+
+                                                                '<li><a href="' + base.get_param(scalarapi.model.urlPrefix + 'import/harvard_art_museums') + '">Harvard Art Museums</a></li>'+
                                                             '</ul>'+
                                                         '</li>'+
                                                         '<li class="dropdown">'+

--- a/system/application/views/melons/cantaloupe/upload.php
+++ b/system/application/views/melons/cantaloupe/upload.php
@@ -294,9 +294,9 @@ Other supported formats: 3gp, aif, flv, mov, mpg, oga, tif, webm<br />
 		<small>IPTC or ID3 fields embedded in the file will auto-populate during upload</small>
 	</td></tr>
 	<tr id="metadata_rows_parent"><td class="field"></td><td><div id="metadata_rows"></div></td></tr>
-        <tr><td>IIIF</td><td>
+		<tr><td>IIIF</td><td>
 		<div class="checkbox">
-			<label><input type="checkbox" id="media_file_url_iiif" name="iiif-url" /> Is IIIF manifest</label>
+			<label><input type="checkbox" id="media_file_url_iiif" name="iiif-url" /> Is IIIF Manifest</label>
 		</div>
 	</td></tr>
 	<tr><td class="field">Choose file</td><td>

--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -482,7 +482,7 @@ function YouTubeGetID(url){
 					promise = $.Deferred();
 					pendingDeferredMedia.OpenSeadragon.push(promise);
 
-                                }else if(typeof Mirador === 'undefined' && this.model.mediaSource.contentType == 'manifest'){
+				}else if(typeof Mirador === 'undefined' && this.model.mediaSource.contentType == 'manifest'){
 					if(typeof pendingDeferredMedia.Mirador == 'undefined'){
 						pendingDeferredMedia.Mirador = [];
 						$.getScript(widgets_uri+'/mediaelement/mirador.min.js',function(){
@@ -1056,9 +1056,9 @@ function YouTubeGetID(url){
 						case 'tiledImage':
 							this.mediaObjectView = new $.DeepZoomImageObjectView(this.model, this);
 						break;
-                        case 'manifest':
-                            this.mediaObjectView = new $.MiradorObjectView(this.model, this);
-                        break;
+						case 'manifest':
+							this.mediaObjectView = new $.MiradorObjectView(this.model, this);
+						break;
 						case 'audio':
 						if (this.model.mediaSource.name == 'SoundCloud') {
 							this.mediaObjectView = new $.SoundCloudAudioObjectView(this.model, this);


### PR DESCRIPTION
This PR contributes the Harvard Art Museums API as an available archive in scalar for discovering IIIF resources by:

- Adding a configuration in `local_settings` for a Harvard Art Museums API key
- Adding the Harvard Art Museums to the list of archives
- Adding an xsl template to digest the Harvard Art Museums API
- Including some minor fixes to functionality and code formatting

## Notes
- An api key from Harvard Art Museums is required in order for this archive to work