### PR TITLE
Don't match dates with ce or ad eras when making year negative

### DIFF
--- a/system/application/views/melons/cantaloupe/js/scalarpage.jquery.js
+++ b/system/application/views/melons/cantaloupe/js/scalarpage.jquery.js
@@ -91,7 +91,7 @@
 
                     if(date_parts[4]!=undefined){
                         var era = date_parts[4].toLowerCase();
-                        if(($.inArray(era, ['bce','bc']) > -1 && entry.start_date.year > 0) || ($.inArray(era, ['ce','ad']) > -1 && entry.start_date.year > 0)){
+                        if(($.inArray(era, ['bce','bc']) > -1 && entry.start_date.year > 0)){
                             entry.start_date.year *= -1;
                         }
                     }


### PR DESCRIPTION
This fixes issue #210 by removing the condition that matches eras of 'ad' or 'ce' when generating negative dates to be used by timeline components.