### PR TITLE
Always instantiate empty array for variables passed to implode()

### DIFF
--- a/system/application/models/book_model.php
+++ b/system/application/models/book_model.php
@@ -738,8 +738,8 @@ class Book_model extends MY_Model {
 				$this->db->join($this->books_table, $this->pages_table.'.book_id='.$this->books_table.'.book_id');
 				$this->db->where($this->books_table.'.book_id', $book_id);
 				$query = $this->db->get();
+				$book_version_ids = array();
 				if ($query->num_rows()) {
-					$book_version_ids = array();
 					$result = $query->result();
 					foreach ($result as $row) $book_version_ids[] = $row->version_id;
 				}
@@ -749,8 +749,8 @@ class Book_model extends MY_Model {
 				$this->db->join($this->books_table, $this->pages_table.'.book_id='.$this->books_table.'.book_id');
 				$this->db->where($this->books_table.'.book_id', $book_id);
 				$query = $this->db->get();
+				$book_page_ids = array();
 				if ($query->num_rows()) {
-					$book_page_ids = array();
 					$result = $query->result();
 					foreach ($result as $row) $book_page_ids[] = $row->content_id;
 				}


### PR DESCRIPTION
This fixes #213 by instantiating the `$book_version_ids` and `$book_page_ids` arrays even when there are no book versions or pages to avoid passing an undefined variable to `implode()`