### PR TITLE
Exception handling

### DIFF
--- a/system/application/controllers/api.php
+++ b/system/application/controllers/api.php
@@ -108,8 +108,7 @@ Class Api extends CI_Controller {
  		//Session login first
  		if ($this->data['native']===true || $this->data['native']==='true'){
  			$this->user = $this->api_users->do_session_login($this->data['book']->book_id);
- 			if (!$this->user && $this->api_users->is_super()) $this->_output_error(StatusCodes::HTTP_UNAUTHORIZED, 'You do not have permission to modify this book');
- 			if (!$this->user) $this->_output_error(StatusCodes::HTTP_UNAUTHORIZED, 'You are not logged in');
+ 			if (!$this->user && !$this->api_users->is_super()) $this->_output_error(StatusCodes::HTTP_UNAUTHORIZED, 'You are not logged in or do not have permission to modify this book');
  		// API key login
  		} else if (!$this->user = $this->api_users->do_login($this->data['email'], $this->data['api_key'], $this->data['host'], $this->data['book']->book_id)){
  			$this->_output_error(StatusCodes::HTTP_UNAUTHORIZED, 'Could not log in via API key');

--- a/system/application/views/arbors/html5_RDFa/js/form-validation.js
+++ b/system/application/views/arbors/html5_RDFa/js/form-validation.js
@@ -298,7 +298,7 @@ function send_form($form, additional_values, success, redirect_url) {
 	}
 
 	var error = function(message) {
-		alert('Something went wrong while attempting to save: '+message);
+		alert('Something went wrong while attempting to save: '+message.responseJSON.error.message[0].value);
 		send_form_hide_loading();
 	}
 


### PR DESCRIPTION
There are a small handful of error handling issues we have run into that I keep meaning to put into a pull request. But I think I may need a bit of guidance on how you prefer to manage exceptions. This draft starts with one of the issues we've run into.

### Description
A super admin gets an error message when trying to add or modify a page for book where they are not an author:
<img width="1004" alt="Screenshot 2024-12-12 at 10 10 15 AM" src="https://github.com/user-attachments/assets/6208fe29-99a4-4538-8285-b3a0eda3ec33" />

For us, this happens most often when we are working with an author and demonstrating a feature.

### Issue
1. bc2b134
It looks as if [error](https://github.com/anvc/scalar/blob/288f92ae101a008eacb718431b4ec41f2f44c199/system/application/views/arbors/html5_RDFa/js/form-validation.js#L300) is expecting a message but is being passed a XMLHttpRequest object. [Elsewhere](https://github.com/anvc/scalar/blob/288f92ae101a008eacb718431b4ec41f2f44c199/system/application/views/widgets/waldorf/annotator-frontend-scalar.js#L3227) I see you access the error message using the responseJSON method when presented with a similar situation, and that is what I've done here. 
I think there are other error messages that follow this same pattern (e.g., attempt to print a XMLHttpRequest object)--is this the fix you'd like to see?

2. 871e7c8
The other issue is with the logic of this exception. It seems like super admins, who could add themselves to the book's users, should be able to make changes to any book. So, the second commit changes the exception logic to display the error only if the user is not a book author and is not a super admin. 
But let me know if this is an intentional move to provide a method that prevents super admins from accidentally making changes.

