### PR TITLE
fix a number of small user/auth-related error/problems

### DIFF
--- a/system/application/config/local_settings.php
+++ b/system/application/config/local_settings.php
@@ -111,7 +111,7 @@ $config['terms_of_service'] = '';
 $config['privacy_policy'] = '';
 
 // LDAP authentication settings
-$config['use_ldap'] = (getenv('SCALAR_USE_LDAP') ? getenv('SCALAR_USE_LDAP') : false);  // Default: off
+$config['use_ldap'] = getenv('SCALAR_USE_LDAP') ? (getenv('SCALAR_USE_LDAP') === 'true') : false;  // Default: off
 $config['ldap_server'] = (getenv('SCALAR_LDAP_SERVER') ? getenv('SCALAR_LDAP_SERVER') : "ldap://ldap.server.name");  // Use 'ldap://' prefix even if connecting to ldaps
 $config['ldap_port'] = (getenv('SCALAR_LDAP_PORT') ? getenv('SCALAR_LDAP_PORT') : 389);
 $config['ldap_basedn'] = (getenv('SCALAR_LDAP_BASEDN') ? getenv('SCALAR_LDAP_BASEDN') : "dc=organization,dc=tld");
@@ -119,7 +119,7 @@ $config['ldap_uname_field'] = (getenv('SCALAR_LDAP_UNAME_FIELD') ? getenv('SCALA
 $config['ldap_filter'] = (getenv('SCALAR_LDAP_FILTER') ? getenv('SCALAR_LDAP_FILTER') : '');
 
 // Active Directory LDAP settings
-$config['use_ad_ldap'] = (getenv('SCALAR_USE_AD_LDAP') ? getenv('SCALAR_USE_AD_LDAP') : false);  // Default: off
+$config['use_ad_ldap'] = getenv('SCALAR_USE_AD_LDAP') ? (getenv('SCALAR_USE_AD_LDAP') === 'true') : false;  // Default: off
 $config['ad_bind_user'] = (getenv('SCALAR_AD_BIND_USER') ? getenv('SCALAR_AD_BIND_USER') : "");  // Use LDAP Distinguished Name
 $config['ad_bind_pass'] = (getenv('SCALAR_AD_BIND_PASS') ? getenv('SCALAR_AD_BIND_PASS') : "");
    // explicity enable/disable ldap referrals. Expects 1 or 0. If not set, defaults to previous behavior, which is:

--- a/system/application/models/user_model.php
+++ b/system/application/models/user_model.php
@@ -190,7 +190,8 @@ class User_model extends MY_Model {
         if( $set_referrals !== null )
             ldap_set_option($ldapCon, LDAP_OPT_REFERRALS, (int) $set_referrals );
 
-        if ( !ldap_start_tls($ldapCon) ) {
+		// attempt to start TLS only if we're not using LDAPS
+        if ( strpos( $ldap_host, 'ldaps://' ) !== 0 && ! ldap_start_tls($ldapCon) ) {
             throw new Exception('Unable to start TLS on LDAP connection');
         }
 
@@ -798,4 +799,5 @@ class User_model extends MY_Model {
 
 }
 ?>
+
 

--- a/system/application/models/user_model.php
+++ b/system/application/models/user_model.php
@@ -202,6 +202,10 @@ class User_model extends MY_Model {
 
         $ldapSearch = ldap_search($ldapCon, $basedn, $ldapFilter);
 
+		if ( ! $ldapSearch ) {
+			throw new Exception(ldap_error($ldapCon));
+		}
+
         // Found the user, now check the password by trying to bind as that user
         $info = ldap_get_entries($ldapCon, $ldapSearch);
         if ( $info['count'] ) {

--- a/system/application/models/user_model.php
+++ b/system/application/models/user_model.php
@@ -781,8 +781,12 @@ class User_model extends MY_Model {
     	
     	$this->load->model('resource_model', 'resources');
     	$json = $this->resources->get('disallowed_emails');
-    	$arr = json_decode($json, true);
-    	if (empty($arr)) $arr = array();
+		// Ensure we're not passing null to json_decode
+    	if ( ! empty( $json ) ) {
+			$arr = json_decode( $json, true );
+		} else {
+			$arr = array();
+		}
     	if (in_array($email, $arr)) return true;
     	return false;
     	
@@ -790,3 +794,4 @@ class User_model extends MY_Model {
 
 }
 ?>
+


### PR DESCRIPTION
This MR ensures we're not passing `null` to json_encode (when loading user model), which is no longer allowed. This is another fix for #203 (php 8 compat), specifically patching the "passing null to json_encode error/warning). 

This also fixes a few minor LDAP errors: #266, #267, #268

This was not fixed as part of the larger php 8.1 compatibility updates in https://github.com/anvc/scalar/commit/a841ee6a1f4d0a3dd0b20b51a1dee98d14910cc1
